### PR TITLE
xattr 1.1.4 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,23 @@
 {% set name = "xattr" %}
-{% set version = "0.10.1" %}
-{% set bundle = "tar.gz" %}
-{% set hash = "c12e7d81ffaa0605b3ac8c22c2994a8e18a9cf1c59287a1b7722a2289c952ec5" %}
+{% set version = "1.1.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b7b02ecb2270da5b7e7deaeea8f8b528c17368401c2b9d5f63e91f545b45d372
+  patches:
+    - patches/0001-fix-tests-on-osx.patch
 
 build:
-  skip: true  # [win]
+  number: 0
   entry_points:
     - xattr = xattr.tool:main
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38]
+  skip: True  # [win]
 
 requirements:
   build:
@@ -24,20 +25,25 @@ requirements:
   host:
     - python
     - pip
-    - cffi 1.15.1
-    - setuptools
+    - cffi >=1.16.0
+    - setuptools >=68
     - wheel
   run:
     - python
-    - cffi >=1.0.0
+    - cffi >=1.16.0
+
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
   imports:
     - xattr
   commands:
-    - xattr --help
     - pip check
+    - xattr --help
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/xattr/xattr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
 
 requirements:
   build:
+    - patch
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/patches/0001-fix-tests-on-osx.patch
+++ b/recipe/patches/0001-fix-tests-on-osx.patch
@@ -1,0 +1,42 @@
+From c0a5e8218b928050e54bbb7710468ce6c96701e2 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Thu, 3 Apr 2025 22:44:14 -0700
+Subject: [PATCH] fix tests on osx
+
+---
+ tests/test_xattr.py | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tests/test_xattr.py b/tests/test_xattr.py
+index 86658f8..1317956 100644
+--- a/tests/test_xattr.py
++++ b/tests/test_xattr.py
+@@ -39,6 +39,10 @@ class BaseTestXattr(object):
+         if sys.platform.startswith('linux') and 'security.selinux' in x:
+             d['security.selinux'] = x['security.selinux']
+ 
++        # macOS systems may have provenance attribute
++        if sys.platform == 'darwin' and 'com.apple.provenance' in x:
++            d['com.apple.provenance'] = x['com.apple.provenance']
++
+         self.assertEqual(list(x.keys()), list(d.keys()))
+         self.assertEqual(list(x.list()), list(d.keys()))
+         self.assertEqual(dict(x), d)
+@@ -94,7 +98,13 @@ class BaseTestXattr(object):
+                 # Solaris, Linux don't support extended attributes on symlinks
+                 raise unittest.SkipTest("XATTRs on symlink not allowed"
+                                         " on filesystem/platform")
+-            self.assertEqual(dict(realfile), {})
++            expected_attributes = {}
++            # On macOS, account for system-specific attributes
++            if sys.platform == 'darwin':
++                for key in realfile.keys():
++                    if key.startswith('com.apple.'):
++                        expected_attributes[key] = realfile[key]
++            self.assertEqual(dict(realfile), expected_attributes)
+             self.assertEqual(symlink['user.islink'], b'true')
+         finally:
+             os.remove(symlinkPath)
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
xattr 1.1.4 

**Destination channel:** Default

### Links

- [PKG-7491]
- dev_url:        https://github.com/xattr/xattr/tree/v1.1.4
- conda_forge:    https://github.com/conda-forge/xattr-feedstock
- pypi:           https://pypi.org/project/xattr/1.1.4
- pypi inspector: https://inspector.pypi.io/project/xattr/1.1.4

### Explanation of changes:

- new version number


[PKG-7491]: https://anaconda.atlassian.net/browse/PKG-7491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ